### PR TITLE
DNS fixes (alias support and rh/ubuntu fixes) + Role by state configuration [2/26]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-zookeeper.json
+++ b/chef/data_bags/crowbar/bc-template-zookeeper.json
@@ -19,6 +19,9 @@
   "deployment": {
     "zookeeper": {
       "crowbar-revision": 0,
+      "element_states": {
+        "zookeeper-server": [ "readying", "ready", "applying" ]
+      },
       "elements": {},
       "element_order": [
         [

--- a/chef/data_bags/crowbar/bc-template-zookeeper.schema
+++ b/chef/data_bags/crowbar/bc-template-zookeeper.schema
@@ -38,6 +38,16 @@
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
+            "element_states": {
+              "type": "map",
+              "mapping": {
+                = : {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
             "elements": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
This allows for the DNS barclamp to work correctly in ubuntu and redhat.

Update the barclamps to have element_states for mapping their roles to states for when to execute.

 chef/data_bags/crowbar/bc-template-zookeeper.json  |    3 +++
 .../data_bags/crowbar/bc-template-zookeeper.schema |   10 ++++++++++
 2 files changed, 13 insertions(+), 0 deletions(-)
