### PR TITLE
Add os_support stanzas to selected barclamps. [2/12]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -23,6 +23,9 @@ barclamp:
     - hadoop
   member:
     - apachehadoop
+  os_support:
+    - redhat-6.2
+    - centos-6.2
 
 crowbar:
   layout: 1
@@ -31,18 +34,8 @@ crowbar:
   chef_order: 300
 
 rpms:
-  redhat-5.7:
-    repos:
-      - bare cloudera-cdh3 10 http://archive.cloudera.com/redhat/cdh/3/
-  centos-5.7:
-    repos:
-      - bare cloudera-cdh3 10 http://archive.cloudera.com/redhat/cdh/3/
-  redhat-6.2:
-    repos:
-      - bare cloudera-cdh3 10 http://archive.cloudera.com/redhat/6/x86_64/cdh/3
-  centos-6.2:
-    repos:
-      - bare cloudera-cdh3 10 http://archive.cloudera.com/redhat/6/x86_64/cdh/3
+  repos:
+    - bare cloudera-cdh3 10 http://archive.cloudera.com/redhat/6/x86_64/cdh/3
   pkgs:
     - hadoop-zookeeper
     - hadoop-zookeeper-server


### PR DESCRIPTION
This pull request adds os_support stanzas to various barclamps to
allow the dev tool to infer the proper OS for a given build.

 crowbar.yml |   17 +++++------------
 1 file changed, 5 insertions(+), 12 deletions(-)

Crowbar-Pull-ID: 18a9548803fe8236bd2918dcca092fdf4ffa73be

Crowbar-Release: development
